### PR TITLE
Add 'transaction helper function'

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Now you can use your model as usual, and all operations will be automatically wr
 ```php
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller; 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class PostController extends Controller
@@ -54,15 +54,15 @@ class PostController extends Controller
     public function store(Request $request)
     {
        $post = Post::transactional(function () use ($request) {
-       
+
             $model = Post::create($request->validated());
-            
+
             $model->tags()->attach(Tag::inRandomOrder()->take(3)->pluck('id'));
             $model->categories()->attach(Category::inRandomOrder()->take(3)->pluck('id'));
-            
+
             $model->addMediaFromRequest('image')
                 ->toMediaCollection('posts');
-            
+
             // all or nothing rollback automatically
             return $model;
         });
@@ -82,7 +82,7 @@ You can also use the same trait for updating models:
 ```php
 namespace App\Http\Controllers\Api;
 
-use App\Http\Controllers\Controller; 
+use App\Http\Controllers\Controller;
 use App\Models\Post;
 use Illuminate\Http\Request;
 
@@ -91,7 +91,7 @@ class PostController extends Controller
     public function Update(Request $request, Post $post)
     {
         $post = Post::transactional(function () use ($post) {
-        
+
             $post->update([
                 'title' => 'Update title Post v1',
             ]);
@@ -114,7 +114,7 @@ class PostController extends Controller
 You can also delete models using the same trait:
 
 ```php
-namespace App\Http\Controllers\Api; 
+namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Post;
 use Illuminate\Http\Request;
@@ -138,7 +138,36 @@ class PostController extends Controller
 }
 ```
 
+### Or you can use it as a helper function
+
+```php
+namespace App\Http\Controllers\Api;
+use App\Http\Controllers\Controller;
+use App\Models\Post;
+use Illuminate\Http\Request;
+use YSM\Support\transactional;
+
+class PostController extends Controller
+{
+    public function destroy(Post $post)
+    {
+
+        $post = transactional(function () use ($post) {
+            $post->delete();
+            // If you want to perform any additional operations after deletion,
+            // you can do so here. For example, logging or cleaning up related data.
+            // If the deletion fails, the transaction will automatically roll back.
+            return $post;
+        });
+
+        return response()->json([
+            'message' => 'Post deleted successfully',
+            'post' => $post,
+        ], 200);
+    }
+}
+```
+
 ### Thanks for using this package! ❤️
 
 If you have any questions or suggestions, feel free to open an issue on GitHub.
- 

--- a/src/Concerns/WithTransaction.php
+++ b/src/Concerns/WithTransaction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace YSM\WithTransaction;
+namespace YSM\Concerns\WithTransaction;
 
 use Closure;
 use Illuminate\Support\Facades\DB;
@@ -47,7 +47,7 @@ trait WithTransaction
      */
     protected static function shouldWrapStatic(): bool
     {
-        return (new static)->shouldWrap();
+        return (new static())->shouldWrap();
     }
 
     /**
@@ -74,7 +74,7 @@ trait WithTransaction
             return parent::save($options);
         }
 
-        return DB::transaction(fn() => parent::save($options));
+        return DB::transaction(fn () => parent::save($options));
     }
 
     /**
@@ -109,7 +109,7 @@ trait WithTransaction
             return $callback(new static());
         }
 
-        return DB::transaction(fn() => $callback(new static()));
+        return DB::transaction(fn () => $callback(new static()));
     }
 
     /**
@@ -127,7 +127,7 @@ trait WithTransaction
             return tap($this)->fill($attributes)->save($options);
         }
 
-        return DB::transaction(fn() => tap($this)->fill($attributes)->save($options));
+        return DB::transaction(fn () => tap($this)->fill($attributes)->save($options));
     }
 
     /**
@@ -142,7 +142,7 @@ trait WithTransaction
             return parent::delete();
         }
 
-        return DB::transaction(fn() => parent::delete());
+        return DB::transaction(fn () => parent::delete());
     }
 
     /**
@@ -157,7 +157,7 @@ trait WithTransaction
             return parent::forceDelete();
         }
 
-        return DB::transaction(fn() => parent::forceDelete());
+        return DB::transaction(fn () => parent::forceDelete());
     }
 
     /**
@@ -172,7 +172,7 @@ trait WithTransaction
             return parent::restore();
         }
 
-        return DB::transaction(fn() => parent::restore());
+        return DB::transaction(fn () => parent::restore());
     }
 
     /**
@@ -209,7 +209,7 @@ trait WithTransaction
 
         try {
             return $this->shouldWrap()
-                ? DB::transaction(fn() => $callback($this))
+                ? DB::transaction(fn () => $callback($this))
                 : $callback($this);
         } finally {
             $this->wrapInTransaction = $original;

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace YSM\Support;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Execute a callback within a database transaction.
+ *
+ * @param Closure $callback
+ * @return mixed
+ */
+function transactional(Closure $callback): mixed
+{
+    return DB::transaction($callback);
+}
+
+


### PR DESCRIPTION
Hi there I have this idea. When I saw your package, Check this idea,

   To keep our models separate from the details of our database 
 I suggest  using the **transactional()** function and wrapping the logic within that function, instead of writing **post::transactional()**
So we keep our models far from the database details. I mentioned an example in the README file.